### PR TITLE
Use @fastly/cli in the starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Get started with Remix on Compute@Edge with a starter kit.
 Prerequisites:
 
 - Node >= 16.13
-- [Fastly CLI](https://developer.fastly.com/learning/tools/cli) >= 7.0
 
 You will be running two processes during development:
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -10,3 +10,4 @@ service_id = ""
 
 [scripts]
 build = "npm run build"
+post_init = "npm install"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@fastly/cli": "^10.14.0",
     "@fastly/compute-js-static-publish": "^6.0.0",
     "@fastly/js-compute": "^3.0.0",
     "@remix-run/dev": "^2.5.1",


### PR DESCRIPTION
This PR makes changes:

* Changes to **package.json** to enable usage without a global installation of the Fastly CLI:
   * Adds `@fastly/cli` to `devDependencies` so that it's available when using the starter kit, as a tool used to build and run or publish the application.
   * Makes sure that `scripts` contains `start` and `deploy` scripts as applicable.

* Adds instructions to the README describing how to initialize an application using the starter kit, as well as how to run it locally or publish it to a Fastly service, as applicable.

* Adds `post_init` script to run `npm install` if it was not present.