### PR TITLE
Consistent package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,28 @@
 {
+  "type": "module",
   "private": true,
   "sideEffects": false,
-  "type": "module",
+  "dependencies": {
+    "@fastly/js-compute": "^3.33.2",
+    "@fastly/remix-server-adapter": "^4.0.0",
+    "@fastly/remix-server-runtime": "^4.0.0",
+    "@remix-run/css-bundle": "^2.5.1",
+    "@remix-run/react": "^2.5.1",
+    "isbot": "^4.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@fastly/cli": "^11.0.0",
+    "@fastly/compute-js-static-publish": "^6.0.0",
+    "@remix-run/dev": "^2.5.1",
+    "@remix-run/eslint-config": "^2.5.1",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "eslint": "^8.23.1",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.0.0"
+  },
   "scripts": {
     "build": "npm run build:remix && npm run build:fastly",
     "build:remix": "remix build",
@@ -12,29 +33,5 @@
     "dev:fastly": "fastly compute serve --watch",
     "dev": "run-p \"dev:*\"",
     "start": "fastly compute serve"
-  },
-  "dependencies": {
-    "@fastly/remix-server-adapter": "^4.0.0",
-    "@fastly/remix-server-runtime": "^4.0.0",
-    "@remix-run/css-bundle": "^2.5.1",
-    "@remix-run/react": "^2.5.1",
-    "isbot": "^4.1.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
-    "@fastly/cli": "^10.14.0",
-    "@fastly/compute-js-static-publish": "^6.0.0",
-    "@fastly/js-compute": "^3.0.0",
-    "@remix-run/dev": "^2.5.1",
-    "@remix-run/eslint-config": "^2.5.1",
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
-    "eslint": "^8.23.1",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^5.0.0"
-  },
-  "engines": {
-    "node": ">=16.13"
   }
 }


### PR DESCRIPTION
This PR makes package.json consistent across the various JavaScript (TypeScript) starter kits.

1. As this is a template, removes fields that we would not want downstream projects to inherit if they were set:
   * package name, author, bugs, homepage, repository, license, version

2. As the package created from the template is an application:
   * sets private: true
   * removes main if it was set

3. Removes any engine requirement, as it is unneeded (and has been removed from js-compute since 3.14.0 as well).

4. Updates @fastly/cli to version ^11.0.0 (latest major release) and @fastly/js-compute to ^3.33.2 (includes latest crash fix)
   * if package depends on webpack, updates it to ^5.98.0, which includes a security fix

5. Places `dependencies`, `devDependencies`, `scripts` consistently in this order.
